### PR TITLE
Fix/deleted user ticket

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 group = "eu.greev"
+version = "1.1.2"
 
 repositories {
     mavenCentral()

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/LoadTicket.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/LoadTicket.java
@@ -45,7 +45,7 @@ public class LoadTicket extends AbstractCommand {
                 .setAuthor(event.getMember().getEffectiveName(), null, event.getMember().getEffectiveAvatarUrl())
                 .addField("Topic", ticket.getTopic(), false)
                 .addField("Owner", ticket.getOwner().getAsMention(), false)
-                .addField("Closer", ticket.getCloser().getAsMention(), false);
+                .addField("Closer", ticket.getCloser() == null ? "No closer" : ticket.getCloser().getAsMention(), false);
 
         if (ticket.getSupporter() != null)
             builder.addField("Supporter", ticket.getSupporter().getAsMention(), false);

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/LoadTicket.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/LoadTicket.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.util.Strings;
 
 import java.awt.*;
 
-public class LoadTicket extends AbstractCommand{
+public class LoadTicket extends AbstractCommand {
 
     public LoadTicket(Config config, TicketService ticketService, EmbedBuilder missingPerm, JDA jda) {
         super(config, ticketService, missingPerm, jda);

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/ThreadJoin.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/ThreadJoin.java
@@ -48,5 +48,12 @@ public class ThreadJoin extends AbstractCommand {
             return;
         }
         thread.addThreadMember(event.getMember()).queue();
+
+        event.replyEmbeds(new EmbedBuilder().setColor(Color.decode(config.getColor()))
+                        .setFooter(config.getServerName(), config.getServerLogo())
+                        .addField("✅ **Successfully joined**", "You were successfully added to the Ticket thread #" + ticket.getId(), false)
+                        .build())
+                .setEphemeral(true)
+                .queue();
     }
 }

--- a/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketData.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketData.java
@@ -25,7 +25,7 @@ public class TicketData {
         Ticket.TicketBuilder builder = jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM tickets WHERE ticketID = ?")
                 .bind(0, ticketID)
                 .map((resultSet, index, ctx) -> {
-                    if (!resultSet.next()) {
+                    if (resultSet.getString("owner").equals(Strings.EMPTY)) {
                         return null;
                     }
 

--- a/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketData.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketData.java
@@ -22,16 +22,20 @@ public class TicketData {
     }
 
     protected Ticket loadTicket(int ticketID) {
-        Ticket.TicketBuilder builder = Ticket.builder().ticketData(this).id(ticketID);
-
-        jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM tickets WHERE ticketID = ?")
+        Ticket.TicketBuilder builder = jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM tickets WHERE ticketID = ?")
                 .bind(0, ticketID)
                 .map((resultSet, index, ctx) -> {
-                    jda.retrieveUserById(resultSet.getString("owner")).complete();
-                    builder.textChannel(jda.getTextChannelById(resultSet.getString("channelID")))
+                    if (!resultSet.next()) {
+                        return null;
+                    }
+
+                    Ticket.TicketBuilder ticketBuilder = Ticket.builder()
+                            .ticketData(this)
+                            .id(ticketID)
+                            .textChannel(jda.getTextChannelById(resultSet.getString("channelID")))
                             .threadChannel(!resultSet.getString("threadID").equals(Strings.EMPTY)
                                     ? jda.getThreadChannelById(resultSet.getString("threadID")) : null)
-                            .owner(jda.getUserById(resultSet.getString("owner")))
+                            .owner(jda.retrieveUserById(resultSet.getString("owner")).complete())
                             .topic(resultSet.getString("topic"))
                             .info(resultSet.getString("info"))
                             .isWaiting(resultSet.getBoolean("isWaiting"))
@@ -39,16 +43,20 @@ public class TicketData {
                             .involved(new ArrayList<>(List.of(resultSet.getString("involved").split(", "))));
 
                     if (!resultSet.getString("closer").equals(Strings.EMPTY)) {
-                        builder.closer(jda.retrieveUserById(resultSet.getString("closer")).complete());
+                        ticketBuilder.closer(jda.retrieveUserById(resultSet.getString("closer")).complete());
                     }
 
                     if (!resultSet.getString("supporter").equals(Strings.EMPTY)) {
-                        builder.supporter(jda.retrieveUserById(resultSet.getString("supporter")).complete());
+                        ticketBuilder.supporter(jda.retrieveUserById(resultSet.getString("supporter")).complete());
                     }
 
-                    return null;
+                    return ticketBuilder;
                 })
-                .findFirst());
+                .findFirst()).orElse(null);
+
+        if (builder == null) {
+            return null;
+        }
 
         return builder.transcript(transcriptData.loadTranscript(ticketID)).build();
     }

--- a/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
@@ -270,7 +270,7 @@ public class TicketService {
 
         return optionalTicket.orElseGet(() -> {
             Ticket loadedTicket = ticketData.loadTicket(idLong);
-            if (loadedTicket.getOwner() != null) {
+            if (loadedTicket != null) {
                 allCurrentTickets.add(loadedTicket);
             }
             return loadedTicket;
@@ -284,7 +284,7 @@ public class TicketService {
 
         return optionalTicket.orElseGet(() -> {
             Ticket loadedTicket = ticketData.loadTicket(ticketID);
-            if (loadedTicket.getOwner() != null) {
+            if (loadedTicket != null) {
                 allCurrentTickets.add(loadedTicket);
             }
             return loadedTicket;

--- a/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
@@ -270,10 +270,9 @@ public class TicketService {
 
         return optionalTicket.orElseGet(() -> {
             Ticket loadedTicket = ticketData.loadTicket(idLong);
-            if (loadedTicket.getOwner() == null) {
-                return null;
+            if (loadedTicket.getOwner() != null) {
+                allCurrentTickets.add(loadedTicket);
             }
-            allCurrentTickets.add(loadedTicket);
             return loadedTicket;
         });
     }
@@ -285,10 +284,9 @@ public class TicketService {
 
         return optionalTicket.orElseGet(() -> {
             Ticket loadedTicket = ticketData.loadTicket(ticketID);
-            if (loadedTicket.getOwner() == null) {
-                return null;
+            if (loadedTicket.getOwner() != null) {
+                allCurrentTickets.add(loadedTicket);
             }
-            allCurrentTickets.add(loadedTicket);
             return loadedTicket;
         });
     }


### PR DESCRIPTION
This PR fixes the bug that you cant load a ticket if the original creator account got deleted, it also now sends a message when joining a ticket thread to avoid confusion (before it just displayed "The application did not respond")