### PR TITLE
Implement scroll menu in get-tickets command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "eu.greev"
-version = "1.2.2"
+version = "1.3.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/eu/greev/dcbot/Main.java
+++ b/src/main/java/eu/greev/dcbot/Main.java
@@ -4,9 +4,7 @@ import eu.greev.dcbot.ticketsystem.TicketListener;
 import eu.greev.dcbot.ticketsystem.interactions.Interaction;
 import eu.greev.dcbot.ticketsystem.interactions.TicketClaim;
 import eu.greev.dcbot.ticketsystem.interactions.TicketClose;
-import eu.greev.dcbot.ticketsystem.interactions.buttons.GetTranscript;
-import eu.greev.dcbot.ticketsystem.interactions.buttons.TicketConfirm;
-import eu.greev.dcbot.ticketsystem.interactions.buttons.TicketNevermind;
+import eu.greev.dcbot.ticketsystem.interactions.buttons.*;
 import eu.greev.dcbot.ticketsystem.interactions.commands.*;
 import eu.greev.dcbot.ticketsystem.interactions.modals.Application;
 import eu.greev.dcbot.ticketsystem.interactions.modals.Bug;
@@ -162,6 +160,9 @@ public class Main {
 
         registerInteraction("thread add", new ThreadAdd(config, ticketService, wrongChannel, missingPerm, jda));
         registerInteraction("thread join", new ThreadJoin(config, ticketService, wrongChannel, missingPerm, jda));
+
+        registerInteraction("tickets-forwards", new TicketsForward(ticketService));
+        registerInteraction("tickets-backwards", new TicketsBackwards(ticketService));
 
         log.info("Started: " + OffsetDateTime.now(ZoneId.systemDefault()));
     }

--- a/src/main/java/eu/greev/dcbot/Main.java
+++ b/src/main/java/eu/greev/dcbot/Main.java
@@ -17,6 +17,7 @@ import eu.greev.dcbot.ticketsystem.interactions.selections.TicketPardon;
 import eu.greev.dcbot.ticketsystem.service.TicketData;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
 import eu.greev.dcbot.utils.Config;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -24,6 +25,7 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.exceptions.InvalidTokenException;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
@@ -51,8 +53,10 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class Main {
-    private static Jdbi jdbi;
     public static final Map<String, Interaction> INTERACTIONS = new HashMap<>();
+    @Getter private static String createCommandId;
+    @Getter private static String getTicketCommandId;
+    private static Jdbi jdbi;
 
     public static void main(String[] args) throws InterruptedException, IOException {
         PropertyConfigurator.configure(Main.class.getClassLoader().getResourceAsStream("log4j2.properties"));
@@ -123,7 +127,14 @@ public class Main {
                         .addSubcommands(new SubcommandData("add", "Add a staff member to the ticket thread")
                                 .addOption(OptionType.USER, "staff", "Staff member to add", true))
                         .addSubcommands(new SubcommandData("join", "Join the ticket thread")))
-                ).queue();
+                ).queue(s -> s.get(0).getSubcommands().forEach(c ->  {
+                    if (c.getName().equals("get-tickets")) {
+                            getTicketCommandId = c.getId();
+                    } else if (c.getName().equals("create")) {
+                        createCommandId = c.getId();
+                    }
+                })
+        );
 
         EmbedBuilder missingPerm = new EmbedBuilder().setColor(Color.RED)
                 .addField("❌ **Missing permission**", "You are not permitted to use this command!", false);

--- a/src/main/java/eu/greev/dcbot/ticketsystem/TicketListener.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/TicketListener.java
@@ -185,9 +185,9 @@ public class TicketListener extends ListenerAdapter {
                     .setColor(Color.decode(config.getColor()))
                     .addField(new MessageEmbed.Field("**Support request**", """
                         You have questions or a problem?
-                        Just click the one of the buttons below or use </ticket create:1030837558994804847> somewhere else.
+                        Just click the one of the buttons below or use </ticket create:%s> somewhere else.
                         We will try to handle your ticket as soon as possible.
-                        """, false));
+                        """.formatted(Main.getCreateCommandId()), false));
 
             StringSelectMenu.Builder selectionBuilder = StringSelectMenu.create("ticket-create-topic")
                     .setPlaceholder("Select your ticket topic")

--- a/src/main/java/eu/greev/dcbot/ticketsystem/entities/ScrollEntity.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/entities/ScrollEntity.java
@@ -1,0 +1,12 @@
+package eu.greev.dcbot.ticketsystem.entities;
+
+import lombok.Data;
+
+@Data
+public class ScrollEntity {
+    private final long handlerId;
+    private final long userId;
+    private int currentPage = 1;
+    private final int maxPage;
+    private final long timeCreated;
+}

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsBackwards.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsBackwards.java
@@ -1,11 +1,12 @@
 package eu.greev.dcbot.ticketsystem.interactions.buttons;
 
+import eu.greev.dcbot.Main;
+import eu.greev.dcbot.ticketsystem.entities.ScrollEntity;
 import eu.greev.dcbot.ticketsystem.entities.Ticket;
 import eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
 import lombok.AllArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
@@ -21,12 +22,23 @@ public class TicketsBackwards extends AbstractButton{
     @Override
     public void execute(Event evt) {
         ButtonInteractionEvent event = (ButtonInteractionEvent) evt;
-        MessageEmbed embed = event.getMessage().getEmbeds().get(0);
+        EmbedBuilder builder = new EmbedBuilder(event.getMessage().getEmbeds().get(0));
 
-        EmbedBuilder builder = new EmbedBuilder(embed);
+        ScrollEntity entity = GetTickets.PAGE_SCROLL_CACHE.stream()
+                .filter(e -> e.getHandlerId() == event.getUser().getIdLong())
+                .findFirst()
+                .orElse(null);
 
-        int maxPage = Integer.parseInt(embed.getDescription().split("/")[1]);
-        int currentPage = Integer.parseInt(embed.getDescription().split("[/ ]")[1]);
+        if (entity == null) {
+            EmbedBuilder error = new EmbedBuilder()
+                    .setColor(Color.RED)
+                    .setDescription("❌ **This button expired, please use </ticket get-tickets:%s> again**".formatted(Main.getGetTicketCommandId()));
+            event.replyEmbeds(error.build()).setEphemeral(true).queue();
+            return;
+        }
+
+        int maxPage = entity.getMaxPage();
+        int currentPage = entity.getCurrentPage();
 
         builder.clearFields().setDescription("Page %s/%s".formatted(currentPage - 1, maxPage));
 
@@ -36,7 +48,7 @@ public class TicketsBackwards extends AbstractButton{
             return;
         }
 
-        List<Integer> tickets = ticketService.getTicketIdsByOwner(embed.getAuthor().getUrl().split("https://www.discordapp.com/users/")[1]);
+        List<Integer> tickets = ticketService.getTicketIdsByOwner(entity.getUserId());
 
         for (int i = (currentPage-2) * 25; i < (currentPage-1) * 25; i++) {
             if (tickets.size() == i) break;
@@ -50,6 +62,8 @@ public class TicketsBackwards extends AbstractButton{
             }
             builder.addField(GetTickets.generateName(ticket.getTopic(), tickets.get(i)), ticket.getTopic(), false);
         }
+
+        entity.setCurrentPage(currentPage - 1);
 
         event.replyEmbeds(builder.build()).setActionRow(
                 Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsBackwards.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsBackwards.java
@@ -1,0 +1,59 @@
+package eu.greev.dcbot.ticketsystem.interactions.buttons;
+
+import eu.greev.dcbot.ticketsystem.entities.Ticket;
+import eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets;
+import eu.greev.dcbot.ticketsystem.service.TicketService;
+import lombok.AllArgsConstructor;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+
+import java.awt.*;
+import java.util.List;
+
+@AllArgsConstructor
+public class TicketsBackwards extends AbstractButton{
+    private final TicketService ticketService;
+
+    @Override
+    public void execute(Event evt) {
+        ButtonInteractionEvent event = (ButtonInteractionEvent) evt;
+        MessageEmbed embed = event.getMessage().getEmbeds().get(0);
+
+        EmbedBuilder builder = new EmbedBuilder(embed);
+
+        int maxPage = Integer.parseInt(embed.getDescription().split("/")[1]);
+        int currentPage = Integer.parseInt(embed.getDescription().split("[/ ]")[1]);
+
+        builder.clearFields().setDescription("Page %s/%s".formatted(currentPage - 1, maxPage));
+
+        if (currentPage == 1) {
+            builder.setDescription("You already are on the first page").setAuthor(null).setTitle(null);
+            event.replyEmbeds(builder.build()).setEphemeral(true).queue();
+            return;
+        }
+
+        List<Integer> tickets = ticketService.getTicketIdsByOwner(embed.getAuthor().getUrl().split("https://www.discordapp.com/users/")[1]);
+
+        for (int i = (currentPage-2) * 25; i < (currentPage-1) * 25; i++) {
+            if (tickets.size() == i) break;
+            Ticket ticket = ticketService.getTicketByTicketId(tickets.get(i));
+            if (ticket == null) {
+                EmbedBuilder error = new EmbedBuilder()
+                        .setColor(Color.RED)
+                        .setDescription("❌ **Something went wrong, please report this to the Bot creator!**");
+                event.replyEmbeds(error.build()).setEphemeral(true).queue();
+                return;
+            }
+            builder.addField(GetTickets.generateName(ticket.getTopic(), tickets.get(i)), ticket.getTopic(), false);
+        }
+
+        event.replyEmbeds(builder.build()).setActionRow(
+                Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),
+                Button.primary("tickets-forwards", Emoji.fromUnicode("▶️"))
+        ).setEphemeral(true).queue();
+    }
+}

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsBackwards.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsBackwards.java
@@ -5,15 +5,17 @@ import eu.greev.dcbot.ticketsystem.entities.ScrollEntity;
 import eu.greev.dcbot.ticketsystem.entities.Ticket;
 import eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
+import eu.greev.dcbot.utils.TicketEmojis;
 import lombok.AllArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 
 import java.awt.*;
 import java.util.List;
+
+import static eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets.PAGE_SIZE;
 
 @AllArgsConstructor
 public class TicketsBackwards extends AbstractButton{
@@ -50,7 +52,7 @@ public class TicketsBackwards extends AbstractButton{
 
         List<Integer> tickets = ticketService.getTicketIdsByOwner(entity.getUserId());
 
-        for (int i = (currentPage-2) * 25; i < (currentPage-1) * 25; i++) {
+        for (int i = (currentPage-2) * PAGE_SIZE; i < (currentPage-1) * PAGE_SIZE; i++) {
             if (tickets.size() == i) break;
             Ticket ticket = ticketService.getTicketByTicketId(tickets.get(i));
             if (ticket == null) {
@@ -66,8 +68,8 @@ public class TicketsBackwards extends AbstractButton{
         entity.setCurrentPage(currentPage - 1);
 
         event.replyEmbeds(builder.build()).setActionRow(
-                Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),
-                Button.primary("tickets-forwards", Emoji.fromUnicode("▶️"))
+                Button.primary("tickets-backwards", TicketEmojis.BACKWARDS.getEmoji()),
+                Button.primary("tickets-forwards", TicketEmojis.FORWARDS.getEmoji())
         ).setEphemeral(true).queue();
     }
 }

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsForward.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsForward.java
@@ -1,0 +1,59 @@
+package eu.greev.dcbot.ticketsystem.interactions.buttons;
+
+import eu.greev.dcbot.ticketsystem.entities.Ticket;
+import eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets;
+import eu.greev.dcbot.ticketsystem.service.TicketService;
+import lombok.AllArgsConstructor;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+
+import java.awt.*;
+import java.util.List;
+
+@AllArgsConstructor
+public class TicketsForward extends AbstractButton{
+    private final TicketService ticketService;
+
+    @Override
+    public void execute(Event evt) {
+        ButtonInteractionEvent event = (ButtonInteractionEvent) evt;
+        MessageEmbed embed = event.getMessage().getEmbeds().get(0);
+
+        EmbedBuilder builder = new EmbedBuilder(embed);
+
+        int maxPage = Integer.parseInt(embed.getDescription().split("/")[1]);
+        int currentPage = Integer.parseInt(embed.getDescription().split("[/ ]")[1]);
+
+        builder.clearFields().setDescription("Page %s/%s".formatted(currentPage + 1, maxPage));
+
+        if (currentPage == maxPage) {
+            builder.setDescription("You already are on the last page").setAuthor(null).setTitle(null);
+            event.replyEmbeds(builder.build()).setEphemeral(true).queue();
+            return;
+        }
+
+        List<Integer> tickets = ticketService.getTicketIdsByOwner(embed.getAuthor().getUrl().split("https://www.discordapp.com/users/")[1]);
+
+        for (int i = currentPage * 25; i < (currentPage + 1) * 25; i++) {
+            if (tickets.size() == i) break;
+            Ticket ticket = ticketService.getTicketByTicketId(tickets.get(i));
+            if (ticket == null) {
+                EmbedBuilder error = new EmbedBuilder()
+                        .setColor(Color.RED)
+                        .setDescription("❌ **Something went wrong, please report this to the Bot creator!**");
+                event.replyEmbeds(error.build()).setEphemeral(true).queue();
+                return;
+            }
+            builder.addField(GetTickets.generateName(ticket.getTopic(), tickets.get(i)), ticket.getTopic(), false);
+        }
+
+        event.replyEmbeds(builder.build()).setActionRow(
+                Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),
+                Button.primary("tickets-forwards", Emoji.fromUnicode("▶️"))
+        ).setEphemeral(true).queue();
+    }
+}

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsForward.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsForward.java
@@ -5,15 +5,17 @@ import eu.greev.dcbot.ticketsystem.entities.ScrollEntity;
 import eu.greev.dcbot.ticketsystem.entities.Ticket;
 import eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
+import eu.greev.dcbot.utils.TicketEmojis;
 import lombok.AllArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 
 import java.awt.*;
 import java.util.List;
+
+import static eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets.PAGE_SIZE;
 
 @AllArgsConstructor
 public class TicketsForward extends AbstractButton{
@@ -50,7 +52,7 @@ public class TicketsForward extends AbstractButton{
 
         List<Integer> tickets = ticketService.getTicketIdsByOwner(entity.getUserId());
 
-        for (int i = currentPage * 25; i < (currentPage + 1) * 25; i++) {
+        for (int i = currentPage * PAGE_SIZE; i < (currentPage + 1) * PAGE_SIZE; i++) {
             if (tickets.size() == i) break;
             Ticket ticket = ticketService.getTicketByTicketId(tickets.get(i));
             if (ticket == null) {
@@ -66,8 +68,8 @@ public class TicketsForward extends AbstractButton{
         entity.setCurrentPage(currentPage + 1);
 
         event.replyEmbeds(builder.build()).setActionRow(
-                Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),
-                Button.primary("tickets-forwards", Emoji.fromUnicode("▶️"))
+                Button.primary("tickets-backwards", TicketEmojis.BACKWARDS.getEmoji()),
+                Button.primary("tickets-forwards", TicketEmojis.FORWARDS.getEmoji())
         ).setEphemeral(true).queue();
     }
 }

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsForward.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/buttons/TicketsForward.java
@@ -1,11 +1,12 @@
 package eu.greev.dcbot.ticketsystem.interactions.buttons;
 
+import eu.greev.dcbot.Main;
+import eu.greev.dcbot.ticketsystem.entities.ScrollEntity;
 import eu.greev.dcbot.ticketsystem.entities.Ticket;
 import eu.greev.dcbot.ticketsystem.interactions.commands.GetTickets;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
 import lombok.AllArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
@@ -21,12 +22,23 @@ public class TicketsForward extends AbstractButton{
     @Override
     public void execute(Event evt) {
         ButtonInteractionEvent event = (ButtonInteractionEvent) evt;
-        MessageEmbed embed = event.getMessage().getEmbeds().get(0);
+        EmbedBuilder builder = new EmbedBuilder(event.getMessage().getEmbeds().get(0));
 
-        EmbedBuilder builder = new EmbedBuilder(embed);
+        ScrollEntity entity = GetTickets.PAGE_SCROLL_CACHE.stream()
+                .filter(e -> e.getHandlerId() == event.getUser().getIdLong())
+                .findFirst()
+                .orElse(null);
 
-        int maxPage = Integer.parseInt(embed.getDescription().split("/")[1]);
-        int currentPage = Integer.parseInt(embed.getDescription().split("[/ ]")[1]);
+        if (entity == null) {
+            EmbedBuilder error = new EmbedBuilder()
+                    .setColor(Color.RED)
+                    .setDescription("❌ **This button expired, please use </ticket get-tickets:%s> again**".formatted(Main.getGetTicketCommandId()));
+            event.replyEmbeds(error.build()).setEphemeral(true).queue();
+            return;
+        }
+
+        int maxPage = entity.getMaxPage();
+        int currentPage = entity.getCurrentPage();
 
         builder.clearFields().setDescription("Page %s/%s".formatted(currentPage + 1, maxPage));
 
@@ -36,7 +48,7 @@ public class TicketsForward extends AbstractButton{
             return;
         }
 
-        List<Integer> tickets = ticketService.getTicketIdsByOwner(embed.getAuthor().getUrl().split("https://www.discordapp.com/users/")[1]);
+        List<Integer> tickets = ticketService.getTicketIdsByOwner(entity.getUserId());
 
         for (int i = currentPage * 25; i < (currentPage + 1) * 25; i++) {
             if (tickets.size() == i) break;
@@ -50,6 +62,8 @@ public class TicketsForward extends AbstractButton{
             }
             builder.addField(GetTickets.generateName(ticket.getTopic(), tickets.get(i)), ticket.getTopic(), false);
         }
+
+        entity.setCurrentPage(currentPage + 1);
 
         event.replyEmbeds(builder.build()).setActionRow(
                 Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/GetTickets.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/GetTickets.java
@@ -5,8 +5,11 @@ import eu.greev.dcbot.ticketsystem.service.TicketService;
 import eu.greev.dcbot.utils.Config;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.Event;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
 
 import java.awt.*;
 import java.util.List;
@@ -17,7 +20,6 @@ public class GetTickets extends AbstractCommand {
         super(config, ticketService, missingPerm, jda);
     }
 
-
     @Override
     public void execute(Event evt) {
         SlashCommandInteractionEvent event = (SlashCommandInteractionEvent) evt;
@@ -25,32 +27,40 @@ public class GetTickets extends AbstractCommand {
             event.replyEmbeds(missingPerm.setFooter(config.getServerName(), config.getServerLogo()).build()).setEphemeral(true).queue();
             return;
         }
-        List<Integer> tickets = ticketService.getTicketIdsByOwner(event.getOption("member").getAsUser());
+        User user = event.getOption("member").getAsUser();
+        List<Integer> tickets = ticketService.getTicketIdsByOwner(user.getId());
         EmbedBuilder builder = new EmbedBuilder()
+                .setAuthor(user.getName(), "https://www.discordapp.com/users/" + user.getId(), user.getAvatarUrl())
+                .setTitle("This user opened following tickets:")
                 .setFooter(config.getServerName(), config.getServerLogo())
                 .setColor(Color.decode(config.getColor()));
 
         if (tickets.isEmpty()) {
-            builder.setColor(Color.RED)
-                    .setDescription("This user never opened a ticket");
-        } else {
-            builder.setTitle("This user opened following tickets:");
-            for (Integer id : tickets) {
-                Ticket ticket = ticketService.getTicketByTicketId(id);
-                if (ticket == null) {
-                    EmbedBuilder error = new EmbedBuilder()
-                            .setColor(Color.RED)
-                            .setDescription("❌ **Something went wrong, please report this to the Bot creator!**");
-                    event.replyEmbeds(error.build()).setEphemeral(true).queue();
-                    return;
-                }
-                builder.addField(generateName(ticket.getTopic(), id), ticket.getTopic(), false);
-            }
+            builder.setColor(Color.RED).setTitle("This user never opened a ticket");
+            event.replyEmbeds(builder.build()).setEphemeral(true).queue();
+            return;
         }
-        event.replyEmbeds(builder.build()).setEphemeral(true).queue();
+
+        for (int i = 0; i < 25; i++) {
+            if (tickets.size() - 1 == i) break;
+            Ticket ticket = ticketService.getTicketByTicketId(tickets.get(i));
+            if (ticket == null) {
+                EmbedBuilder error = new EmbedBuilder()
+                        .setColor(Color.RED)
+                        .setDescription("❌ **Something went wrong, please report this to the Bot creator!**");
+                event.replyEmbeds(error.build()).setEphemeral(true).queue();
+                return;
+            }
+            builder.addField(generateName(ticket.getTopic(), tickets.get(i)), ticket.getTopic(), false);
+        }
+
+        event.replyEmbeds(builder.setDescription("Page 1/%d".formatted(tickets.size() / 25 + (tickets.size() % 25 == 0 ? 0 : 1))).build()).setActionRow(
+                Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),
+                Button.primary("tickets-forwards", Emoji.fromUnicode("▶️"))
+        ).setEphemeral(true).queue();
     }
 
-    private String generateName(String topic, int ticketId) {
+    public static String generateName(String topic, int ticketId) {
         String name;
         if (topic.equals("Bugreport")) {
             name = "Bugreport #" + ticketId;

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/GetTickets.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/GetTickets.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 
 import java.awt.*;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
@@ -30,7 +31,10 @@ public class GetTickets extends AbstractCommand {
         new Timer().schedule(new TimerTask() {
             @Override
             public void run() {
-                PAGE_SCROLL_CACHE.removeIf(entity -> Instant.now().toEpochMilli() - entity.getTimeCreated() > TimeUnit.HOURS.toMillis(12));
+                PAGE_SCROLL_CACHE.removeIf(entity -> Instant.now()
+                        .minus(12, ChronoUnit.HOURS)
+                        .isAfter(Instant.ofEpochMilli(entity.getTimeCreated()))
+                );
             }
         }, 0, TimeUnit.MINUTES.toMillis(5));
     }

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/GetTickets.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/GetTickets.java
@@ -1,5 +1,6 @@
 package eu.greev.dcbot.ticketsystem.interactions.commands;
 
+import eu.greev.dcbot.ticketsystem.entities.ScrollEntity;
 import eu.greev.dcbot.ticketsystem.entities.Ticket;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
 import eu.greev.dcbot.utils.Config;
@@ -12,12 +13,24 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
 
 public class GetTickets extends AbstractCommand {
+    public static final List<ScrollEntity> PAGE_SCROLL_CACHE = new ArrayList<>();
 
     public GetTickets(Config config, TicketService ticketService, EmbedBuilder missingPerm, JDA jda) {
         super(config, ticketService, missingPerm, jda);
+
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                PAGE_SCROLL_CACHE.removeIf(entity -> System.currentTimeMillis() - entity.getTimeCreated() > TimeUnit.HOURS.toMillis(12));
+            }
+        }, 0, TimeUnit.MINUTES.toMillis(5));
     }
 
     @Override
@@ -28,9 +41,9 @@ public class GetTickets extends AbstractCommand {
             return;
         }
         User user = event.getOption("member").getAsUser();
-        List<Integer> tickets = ticketService.getTicketIdsByOwner(user.getId());
+        List<Integer> tickets = ticketService.getTicketIdsByOwner(user.getIdLong());
         EmbedBuilder builder = new EmbedBuilder()
-                .setAuthor(user.getName(), "https://www.discordapp.com/users/" + user.getId(), user.getAvatarUrl())
+                .setAuthor(user.getName(), null, user.getAvatarUrl())
                 .setTitle("This user opened following tickets:")
                 .setFooter(config.getServerName(), config.getServerLogo())
                 .setColor(Color.decode(config.getColor()));
@@ -54,10 +67,14 @@ public class GetTickets extends AbstractCommand {
             builder.addField(generateName(ticket.getTopic(), tickets.get(i)), ticket.getTopic(), false);
         }
 
-        event.replyEmbeds(builder.setDescription("Page 1/%d".formatted(tickets.size() / 25 + (tickets.size() % 25 == 0 ? 0 : 1))).build()).setActionRow(
+        int maxPage = tickets.size() / 25 + (tickets.size() % 25 == 0 ? 0 : 1);
+        PAGE_SCROLL_CACHE.removeIf(e -> e.getHandlerId() == event.getMember().getIdLong());
+        ScrollEntity scrollEntity = new ScrollEntity(event.getMember().getIdLong(), user.getIdLong(), maxPage, System.currentTimeMillis());
+
+        event.replyEmbeds(builder.setDescription("Page 1/%d".formatted(maxPage)).build()).setActionRow(
                 Button.primary("tickets-backwards", Emoji.fromUnicode("◀️")),
                 Button.primary("tickets-forwards", Emoji.fromUnicode("▶️"))
-        ).setEphemeral(true).queue();
+        ).setEphemeral(true).queue(s -> PAGE_SCROLL_CACHE.add(scrollEntity));
     }
 
     public static String generateName(String topic, int ticketId) {

--- a/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/Setup.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/interactions/commands/Setup.java
@@ -1,5 +1,6 @@
 package eu.greev.dcbot.ticketsystem.interactions.commands;
 
+import eu.greev.dcbot.Main;
 import eu.greev.dcbot.ticketsystem.service.TicketService;
 import eu.greev.dcbot.utils.Config;
 import lombok.extern.slf4j.Slf4j;
@@ -101,9 +102,9 @@ public class Setup extends AbstractCommand {
                 .setColor(color)
                 .addField(new MessageEmbed.Field("**Support request**", """
                         You have questions or a problem?
-                        Just click the one of the buttons below or use </ticket create:1030837558994804847> somewhere else.
+                        Just click the one of the buttons below or use </ticket create:%s> somewhere else.
                         We will try to handle your ticket as soon as possible.
-                        """, false));
+                        """.formatted(Main.getCreateCommandId()), false));
 
         StringSelectMenu.Builder selectionBuilder = StringSelectMenu.create("ticket-create-topic")
                 .setPlaceholder("Select your ticket topic")

--- a/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
@@ -297,8 +297,8 @@ public class TicketService {
         return allCurrentTickets.stream().filter(ticket -> ticket.getCloser() == null).toList();
     }
 
-    public List<Integer> getTicketIdsByOwner(User owner) {
-        return ticketData.getTicketIdsByUser(owner.getId());
+    public List<Integer> getTicketIdsByOwner(String owner) {
+        return ticketData.getTicketIdsByUser(owner);
     }
 
     public @Nullable Ticket getOpenTicket(User owner) {

--- a/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
+++ b/src/main/java/eu/greev/dcbot/ticketsystem/service/TicketService.java
@@ -297,8 +297,8 @@ public class TicketService {
         return allCurrentTickets.stream().filter(ticket -> ticket.getCloser() == null).toList();
     }
 
-    public List<Integer> getTicketIdsByOwner(String owner) {
-        return ticketData.getTicketIdsByUser(owner);
+    public List<Integer> getTicketIdsByOwner(long owner) {
+        return ticketData.getTicketIdsByUser(String.valueOf(owner));
     }
 
     public @Nullable Ticket getOpenTicket(User owner) {

--- a/src/main/java/eu/greev/dcbot/utils/TicketEmojis.java
+++ b/src/main/java/eu/greev/dcbot/utils/TicketEmojis.java
@@ -1,0 +1,14 @@
+package eu.greev.dcbot.utils;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketEmojis {
+    BACKWARDS(Emoji.fromUnicode("◀️")),
+    FORWARDS(Emoji.fromUnicode("▶️"));
+
+    private final Emoji emoji;
+}


### PR DESCRIPTION
Implement such system to scroll through the ticket pages, if a user opened more than 25 tickets to avoid thrown errors
![grafik](https://github.com/greeveu/discord-ticketbot/assets/99122054/5f78c08e-e2b3-4935-81e2-8a77f2b27c51)
